### PR TITLE
TEXO-22: Fix JSON string escape grammar

### DIFF
--- a/examples/json.ts
+++ b/examples/json.ts
@@ -21,8 +21,10 @@ const jsonNumber = Grammar.mapSchema(
   Schema.Finite,
   { to: Number, from: String },
 )
-const jsonString: Grammar.Grammar<string> = Grammar.mapSchema(
-  Grammar.lexeme(Grammar.regex(/"(?:[^"\\]|\\.)*"/, "string")),
+export const jsonString: Grammar.Grammar<string> = Grammar.mapSchema(
+  Grammar.lexeme(
+    Grammar.regex(/"(?:[^"\\\u0000-\u001F]|\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4}))*"/, "string"),
+  ),
   Schema.String,
   {
     to: (s) => JSON.parse(s),

--- a/test/json.test.ts
+++ b/test/json.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { jsonString } from "../examples/json.ts"
+import { parseFail, parseOk } from "./helpers.ts"
+
+describe("JSON strings", () => {
+  it("rejects invalid escapes with a ParseError", () => {
+    const error = parseFail('"a\\q"', jsonString)
+
+    assert.equal(error.expected, "string")
+  })
+
+  it("accepts quoted strings and valid JSON escapes", () => {
+    assert.equal(parseOk('"hello"', jsonString), "hello")
+
+    const escaped = String.raw`"\"\\\/\b\f\n\r\t\u0041"`
+    assert.equal(parseOk(escaped, jsonString), '"\\/\b\f\n\r\tA')
+  })
+})


### PR DESCRIPTION
Closes TEXO-22

Tightens the example JSON string grammar to accept only valid JSON escapes and adds regression coverage for typed parse failures and valid escapes.

Verification: pnpm typecheck, pnpm test, pnpm fmt:check, pnpm build, git diff --check