### PR TITLE
TEXO-29: document Effect and Node support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ pnpm add effect-grammar
 
 Depends on Effect v4.
 
+## Compatibility policy
+
+This package pins `effect` to `4.0.0-beta.102` because the current v4 release
+candidate line is not source-compatible with the package yet. In particular, the
+current RC removes the `Schema.TaggedErrorClass` and
+`Schema.UnknownFromJsonString` APIs used by the implementation. The exact pin
+will be reconsidered when Effect provides compatible replacements or this
+package intentionally migrates to the RC API, with the full test, typecheck,
+format, and build checks run against the new lockfile.
+
 ## Grammar
 
 Define an HTTPS endpoint once, then parse it, print it, or derive a validated

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "oxfmt": "^0.61.0",
     "typescript": "^7.0.2"
   },
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
 }


### PR DESCRIPTION
Closes TEXO-29

## Summary

- Add `engines.node >=24.0.0`, matching the repository's Node 24 release workflow.
- Keep the exact `effect@4.0.0-beta.102` pin and document why the current v4 RC is not yet compatible.
- Record the bounded upgrade condition: revisit the pin only after compatible replacements are available for `Schema.TaggedErrorClass` and `Schema.UnknownFromJsonString`, or after an intentional source migration.

Testing the current registry RC (`effect@4.0.0-rc.110`) confirmed the policy: it fails the existing runtime and typecheck because those beta APIs are absent. The lockfile therefore remains unchanged and there is no dependency churn.

## Checks

- `pnpm install --frozen-lockfile`
- `pnpm test` (127 passing)
- `pnpm typecheck`
- `pnpm fmt:check`
- `pnpm build`
- `pnpm pack --dry-run`
- `git diff --check`
